### PR TITLE
remove content validation

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -4,7 +4,6 @@ class Event < ActiveRecord::Base
 
   validates :page, presence: true
   validates :event_type, presence: true
-  validates :content, presence: true
   validates :duration, presence: true
   validates :position, presence: true, uniqueness: { scope: :page_id }
 end


### PR DESCRIPTION
we have to remove content presence validation because we have events
without content, for example `start_processing.action_controller` or
`process_action.action_controller`
